### PR TITLE
create flake.nix, add README.md, format code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# nixosConfigurations
+
+## Installing
+
+```sh
+sudo nixos-rebuild switch --flake .#default
+```
+
+## Updating nixpkgs
+
+```sh
+nix flake update
+```
+
+## Upgrading to a different nixpkgs version
+
+Edit `flake.nix`' `input.nixpkgs` to refer to the new version, e.g.
+
+```nix
+    # ...
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.04";
+```
+or
+```nix
+    # ...
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+```
+
+## Optional: building the nixosConfiguration without switching to it
+
+```sh
+nix build .#nixosConfigurations.default.config.system.build.toplevel
+```

--- a/configuration.nix
+++ b/configuration.nix
@@ -6,7 +6,8 @@
 
 {
   imports =
-    [ # Include the results of the hardware scan.
+    [
+      # Include the results of the hardware scan.
       ./hardware-configuration.nix
     ];
 
@@ -84,7 +85,7 @@
     description = "Val";
     extraGroups = [ "networkmanager" "wheel" ];
     packages = with pkgs; [
-    #  thunderbird
+      #  thunderbird
     ];
   };
 
@@ -104,38 +105,38 @@
 
   # List packages installed in system profile. To search, run:
   # $ nix search wget
-   environment.systemPackages = with pkgs; [
-  	vim # Do not forget to add an editor to edit configuration.nix! The Nano editor is also installed by default.
-  	wget
-	curl
-  gcc
-  git
-	python3Full
-  python312Packages.pip
-	(vscode-with-extensions.override {
-    vscodeExtensions = with vscode-extensions; [
-      ms-python.python
-      ms-vscode.cpptools
-      github.copilot
-      github.copilot-chat
-      esbenp.prettier-vscode
-      pkief.material-icon-theme
-      bbenoist.nix
-      shd101wyy.markdown-preview-enhanced
-    ];
-  })
-	neovim
-  neofetch
-  cairo
-  pango
-  ffmpeg
-  ninja
-  pkg-config
-  cmake
-  clang
+  environment.systemPackages = with pkgs; [
+    vim # Do not forget to add an editor to edit configuration.nix! The Nano editor is also installed by default.
+    wget
+    curl
+    gcc
+    git
+    python3Full
+    python312Packages.pip
+    (vscode-with-extensions.override {
+      vscodeExtensions = with vscode-extensions; [
+        ms-python.python
+        ms-vscode.cpptools
+        github.copilot
+        github.copilot-chat
+        esbenp.prettier-vscode
+        pkief.material-icon-theme
+        bbenoist.nix
+        shd101wyy.markdown-preview-enhanced
+      ];
+    })
+    neovim
+    neofetch
+    cairo
+    pango
+    ffmpeg
+    ninja
+    pkg-config
+    cmake
+    clang
   ];
 
-  
+
 
   # Some programs need SUID wrappers, can be configured further or are
   # started in user sessions.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734737257,
+        "narHash": "sha256-GIMyMt1pkkoXdCq9un859bX6YQZ/iYtukb9R5luazLM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1c6e20d41d6a9c1d737945962160e8571df55daa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+  description = "Val's NixOS configuration";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-24.11";
+  };
+
+  outputs = { self, nixpkgs }: {
+    nixosConfigurations.default = nixpkgs.lib.nixosSystem {
+      modules = [
+        ./configuration.nix
+        ./hardware-configuration.nix
+      ];
+    };
+  };
+}

--- a/hardware-configuration.nix
+++ b/hardware-configuration.nix
@@ -12,7 +12,8 @@
   boot.extraModulePackages = [ ];
 
   fileSystems."/" =
-    { device = "/dev/disk/by-uuid/dac5f32e-1879-4399-9ef7-9177ca6aba30";
+    {
+      device = "/dev/disk/by-uuid/dac5f32e-1879-4399-9ef7-9177ca6aba30";
       fsType = "ext4";
     };
 


### PR DESCRIPTION
Changes:
- `flake.nix` & `flake.lock`: define `nixpkgs` and lock it to a specific commit, output a default `nixosConfiguration`
- add `README.md` file with reminders of how to use
- format other nix files using `nixpkgs_fmt`